### PR TITLE
Increase button corner radius size

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -52,12 +52,12 @@ const CustomButton = styled.button<Compactable>`
         `;
     }
   }}
-  display: inline-flex;
   align-items: center;
-  justify-content: center;
+  display: inline-flex;
+  border-radius: 6px;
   font-size: 1rem;
+  justify-content: center;
   line-height: 1rem;
-  border-radius: 2px;
   margin-right: 0.25rem;
   white-space: nowrap;
 


### PR DESCRIPTION
Increasing `corner-radius` to `6px` from `2px` brings our buttons more in line with [Apple's Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/macos/buttons/push-buttons/).

There have been some [recent studies](https://www.youtube.com/watch?v=A_u2WFTfbcg) about how humans perceive jagged edges as 'hostile/dangerous' (think sharp pointy objects, pointy tree branches), whereas softer edges are perceived as 'cozy/soothing'. I believe this is partially why there has been a big push in recent years to slightly increase `corner-radius` sizes.

I also alphabetized the styles here since I was touching this area of code.