### PR TITLE
Add GitHub action workflow for auto-assigning to main project

### DIFF
--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -1,0 +1,22 @@
+name: Auto Assign to Project(s)
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+  issue_comment:
+    types: [created]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Assign NEW issues and NEW pull requests to project 1
+      uses: simonv3/assign-one-project-github-action@1.3.1
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/simonv3/beam/projects/1'

--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Assign to One Project
     steps:
     - name: Assign NEW issues and NEW pull requests to project 1
-      uses: simonv3/assign-one-project-github-action@1.3.1
+      uses: srggrs/assign-one-project-github-action@1.2.1
       if: github.event.action == 'opened'
       with:
         project: 'https://github.com/simonv3/beam/projects/1'


### PR DESCRIPTION
[GitHub Action: Assign to One Project](https://github.com/marketplace/actions/assign-to-one-project#:~:text=GitHub%20Action%20for%20Assign%20to,columns%20in%20your%20project%20dashboard)

@simonv3, you may have to do this part: 
> Generate a token from the Organisation settings or User Settings and add it as a secret in the repository secrets as `MY_GITHUB_TOKEN`

Including this for reference as well: [GitHub Actions Quickstart](https://docs.github.com/en/actions/quickstart)