### PR TITLE
Fix player header icon dark mode colors

### DIFF
--- a/src/components/AudioWrapper.tsx
+++ b/src/components/AudioWrapper.tsx
@@ -167,6 +167,12 @@ export const AudioWrapper: React.FC<{
             box-shadow: none;
             padding: 0;
             margin-right: 1rem;
+            @media (prefers-color-scheme: dark) {
+              filter: invert(80%);
+            }
+            @media (prefers-color-scheme: light) {
+              background: #fff;;
+            }
           }
         `}
       />

--- a/src/components/AudioWrapper.tsx
+++ b/src/components/AudioWrapper.tsx
@@ -171,7 +171,7 @@ export const AudioWrapper: React.FC<{
               filter: invert(80%);
             }
             @media (prefers-color-scheme: light) {
-              background: #fff;;
+              background: #fff;
             }
           }
         `}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -46,6 +46,9 @@ const Content = styled.div`
       scale: 0.7;
       margin-left: -0.5rem;
       height: 46px;
+      @media (prefers-color-scheme: dark) {
+        filter: invert(1);
+      }
     }
 
     @media (prefers-color-scheme: dark) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,7 @@ const Wrapper = styled.header`
   min-height: 48px;
   border-bottom: 1px solid ${(props) => colorShade(props.theme.colors.text, 20)};
   display: flex;
+  filter: drop-shadow(0 0 0.15rem #000);
   flex-direction: column;
   position: sticky;
   width: 100%;

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -36,7 +36,7 @@ const playerClass = css`
   }
 
   @media (prefers-color-scheme: light) {
-    background: #fff;;
+    background: #fff;
   }
 
   @media (max-width: ${bp.small}px) {

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -29,6 +29,7 @@ const playerClass = css`
   width: 100%;
   z-index: 10;
   bottom: 0;
+  filter: drop-shadow(0 0 0.075rem #000);
 
   @media (prefers-color-scheme: dark) {
     background: #333;

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -29,7 +29,14 @@ const playerClass = css`
   width: 100%;
   z-index: 10;
   bottom: 0;
-  background-color: #fff;
+
+  @media (prefers-color-scheme: dark) {
+    background: #333;
+  }
+
+  @media (prefers-color-scheme: light) {
+    background: #fff;;
+  }
 
   @media (max-width: ${bp.small}px) {
     height: 150px;


### PR DESCRIPTION
I've fixed the `Header` icon logo and audio `Player` component's dark mode colors. I've also added a subtle drop shadow to the `Header` and `Player` for some more separation and slight elevation.

<img width="1792" alt="Screen Shot 2022-06-23 at 11 22 37 PM" src="https://user-images.githubusercontent.com/60944077/175462035-412c9c7f-cebe-4211-a30f-46b0d1d9f4f9.png">

This closes #76.
This closes #89.

Eventually we'll want to implement a toggle for #76 and do this a better way, but this will tide users over for now, and I've created an issue for this: https://github.com/simonv3/beam/issues/163.