### PR TITLE
Suppress drop-shadow in Header and Player

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,7 +17,6 @@ const Wrapper = styled.header`
   min-height: 48px;
   border-bottom: 1px solid ${(props) => colorShade(props.theme.colors.text, 20)};
   display: flex;
-  filter: drop-shadow(0 0 0.15rem #000);
   flex-direction: column;
   position: sticky;
   width: 100%;

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -29,7 +29,7 @@ const playerClass = css`
   width: 100%;
   z-index: 10;
   bottom: 0;
-  filter: drop-shadow(0 0 0.075rem #000);
+  filter: drop-shadow(0 0 0.02rem #000);
 
   @media (prefers-color-scheme: dark) {
     background: #333;


### PR DESCRIPTION
I think I went a little overboard with the `drop-shadow` in https://github.com/simonv3/beam/pull/162, these changes remove `drop-shadow` completely from the Header and reduce it significantly in the Player, so a lot more minimal. I really like how this makes the Player component in `light` mode look as well. Let me know what you think.

<img width="1065" alt="Screen Shot 2022-06-26 at 9 52 34 PM" src="https://user-images.githubusercontent.com/60944077/175851253-4c910884-46b0-46df-9db3-0e57cd5cdd90.png">
<img width="1065" alt="Screen Shot 2022-06-26 at 9 52 52 PM" src="https://user-images.githubusercontent.com/60944077/175851255-c19f7232-8084-4139-bf22-638119b7929c.png">
.