### PR TITLE
Fix album buy price and add euro conversion

### DIFF
--- a/src/components/common/BuyAlbumButton.tsx
+++ b/src/components/common/BuyAlbumButton.tsx
@@ -9,6 +9,7 @@ import {
   fetchUserProfile,
 } from "services/Api";
 import { calculateRemainingCost } from "utils/tracks";
+import { convertCreditsToEuros } from "utils/conversions";
 import Button from "./Button";
 import LoadingSpinner from "./LoadingSpinner";
 import Modal from "./Modal";
@@ -91,7 +92,13 @@ export const BuyAlbumButton: React.FC<{
                 margin-bottom: 1rem;
               `}
             >
-              This will cost <strong>{albumRemainingCost}</strong> credits
+              This will cost
+              <strong>{(albumRemainingCost / 1000).toFixed(2)}</strong> credits
+              (
+              <strong>
+                €{convertCreditsToEuros(albumRemainingCost / 1000)}
+              </strong>
+              )
             </p>
             <div
               className={css`

--- a/src/utils/conversions.ts
+++ b/src/utils/conversions.ts
@@ -1,0 +1,3 @@
+export function convertCreditsToEuros(credits: number) {
+  return (credits * 1.2).toFixed(2); // https://community.resonate.is/t/pricing-and-credits/1854
+}


### PR DESCRIPTION
Found the credit to euro exchange rate [here](https://community.resonate.is/t/pricing-and-credits/1854).

I was digging around to address #161, and realized that, with the help of the helpful post above, the albums were being shown as being [1,000 times more expensive](https://community.resonate.is/t/pricing-and-credits/1854#behind-the-scenes-6) than they should have been to the user.

<img width="1190" alt="Screen Shot 2022-06-26 at 10 38 14 PM" src="https://user-images.githubusercontent.com/60944077/175855615-9b7a97c2-5fd1-4903-8bd4-801f22b85165.png">
