### PR TITLE
fix: update credits web app link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ View the [project board](https://github.com/simonv3/beam/projects/1) where work 
 ## Development
 
 Install yarn if you don't yet have it on your machine by running:
+
 ```bash
 npx install yarn
 ```

--- a/public/preload.js
+++ b/public/preload.js
@@ -7,8 +7,8 @@ const { contextBridge, ipcRenderer } = require("electron");
 // They'll be accessible at "window.versions".
 process.once("loaded", () => {
   contextBridge.exposeInMainWorld("versions", process.versions);
-  contextBridge.exposeInMainWorld('darkMode', {
-    toggle: () => ipcRenderer.invoke('dark-mode:toggle'),
-    system: () => ipcRenderer.invoke('dark-mode:system')
-  })
+  contextBridge.exposeInMainWorld("darkMode", {
+    toggle: () => ipcRenderer.invoke("dark-mode:toggle"),
+    system: () => ipcRenderer.invoke("dark-mode:system"),
+  });
 });

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -120,7 +120,7 @@ const Profile: React.FC = () => {
             </div>
             <small style={{ textAlign: "right" }}>
               Want to add credits to your account? Use{" "}
-              <a href="https://stream.resonate.coop/discover">the web app.</a>
+              <a href="https://id.resonate.coop/account?login_redirect_uri=%2Fweb%2Faccount">the web app.</a>
             </small>
           </div>
           <p className={pClass}>

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -120,7 +120,9 @@ const Profile: React.FC = () => {
             </div>
             <small style={{ textAlign: "right" }}>
               Want to add credits to your account? Use{" "}
-              <a href="https://id.resonate.coop/account?login_redirect_uri=%2Fweb%2Faccount">the web app.</a>
+              <a href="https://id.resonate.coop/account?login_redirect_uri=%2Fweb%2Faccount">
+                the web app.
+              </a>
             </small>
           </div>
           <p className={pClass}>


### PR DESCRIPTION
<img width="437" alt="Screenshot 2022-08-14 at 16 15 01" src="https://user-images.githubusercontent.com/60944077/184541613-856ca57d-b871-4ce6-bbd0-947dd8d80d0c.png">

Now goes here:
https://id.resonate.coop/account?login_redirect_uri=%2Fweb%2Faccount